### PR TITLE
chore(.pre-commit-config.yaml): update ruff version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
- Update the version of the Ruff pre-commit hook from v0.7.0 to v0.7.1