### PR TITLE
chore(.pre-commit-config.yaml): update ruff version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.1
+    rev: v0.8.0
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
- Update the `rev` field in the `ruff` hook of the `https://github.com/astral-sh/ruff-pre-commit` repository in the `.pre-commit-config.yaml` file
- Change the `rev` value from `v0.7.1` to `v0.8.0`