### PR TITLE
chore(.pre-commit-config.yaml): update commitlint-pre-commit-hook to …

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         additional_dependencies: ["bandit[toml]"]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.18.0
+    rev: v9.19.0
     hooks:
       - id: commitlint
         stages: [commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.389
+    rev: v1.1.390
     hooks:
     - id: pyright
       additional_dependencies: ["gif", "lightgbm", "pandas", "scikit-learn", "scipy", "mlforecast", "plotext", "sqlalchemy", "taospy"]


### PR DESCRIPTION
…v9.19.0

- Update the `rev` field of the `commitlint-pre-commit-hook` repository in `.pre-commit-config.yaml` file