### PR TITLE
chore(pre-commit): update vulture to v2.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args: ["--nbqa-shell"]
 
   - repo: https://github.com/jendrikseipp/vulture
-    rev: 'v2.13'  # or any later Vulture version
+    rev: 'v2.14'  # or any later Vulture version
     hooks:
       - id: vulture
 


### PR DESCRIPTION
- Update the vulture hook in the .pre-commit-config.yaml file
- Set the revision to 'v2.14' or any later Vulture version