### PR TITLE
chore(config): update bandit to version 1.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: vulture
 
   - repo: https://github.com/PyCQA/bandit
-    rev: '1.7.10' # Update me!
+    rev: '1.8.0' # Update me!
     hooks:
       - id: bandit
         args: ["-c", "pyproject.toml"]


### PR DESCRIPTION
- Update the `bandit` hook in `.pre-commit-config.yaml` to use version 1.8.0 of the `bandit` package.
- Modify the `rev` parameter for the `bandit` hook to "1.8.0".