### PR TITLE
chore(repo): update ruff-pre-commit to v0.8.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.2
+    rev: v0.8.3
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
- Update the `rev` field in `.pre-commit-config.yaml` for `ruff-pre-commit` repo
- Set `rev` to `v0.8.3`