### PR TITLE
chore(.pre-commit-config.yaml): update typos version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.28.1
+    rev: v1.28.3
     hooks:
       - id: typos
 


### PR DESCRIPTION
- Update the `rev` value of the `typos` hook to `v1.28.3` in the `.pre-commit-config.yaml` file.