### PR TITLE
chore(.pre-commit-config.yaml): update pyright-python to v1.1.393

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.390
+    rev: v1.1.393
     hooks:
     - id: pyright
       additional_dependencies: ["gif", "lightgbm", "pandas", "scikit-learn", "scipy", "mlforecast", "plotext", "sqlalchemy", "taospy"]


### PR DESCRIPTION
- Update the `rev` field of the `https://github.com/RobertCraigie/pyright-python` repository in the `.pre-commit-config.yaml` file
- Set the `rev` to `v1.1.393`