### PR TITLE
chore(pre-commit): update pyright version to v1.1.394

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.393
+    rev: v1.1.394
     hooks:
     - id: pyright
       additional_dependencies: ["gif", "lightgbm", "pandas", "scikit-learn", "scipy", "mlforecast", "plotext", "sqlalchemy", "taospy"]


### PR DESCRIPTION
- Updated the `pyright` version in `.pre-commit-config.yaml` from v1.1.393 to v1.1.394.
- This change ensures compatibility with the latest features and bug fixes.