### PR TITLE
chore(pre-commit): update commitlint version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         additional_dependencies: ["bandit[toml]"]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.19.0
+    rev: v9.21.0
     hooks:
       - id: commitlint
         stages: [commit-msg]


### PR DESCRIPTION
- Update commitlint pre-commit hook version from v9.19.0 to v9.21.0
- Ensure compatibility with latest features and bug fixes